### PR TITLE
Feature fix tiffdtype

### DIFF
--- a/imctools/io/tiffwriter.py
+++ b/imctools/io/tiffwriter.py
@@ -18,9 +18,15 @@ class TiffWriter(object):
     """
 
     """
-    pixeltype_dict = ({np.int64().dtype: ome.PT_INT16,
+    pixeltype_dict = ({np.int64().dtype: ome.PT_INT32,
+                       np.int32().dtype: ome.PT_INT32,
+                       np.int16().dtype: ome.PT_INT16,
+                       np.uint16().dtype: ome.PT_UINT16,
+                       np.uint32().dtype: ome.PT_UINT32,
+                       np.uint8().dtype: ome.PT_UINT8,
                        np.float32().dtype: ome.PT_FLOAT,
-                       np.float64().dtype: ome.PT_FLOAT})
+                       np.float64().dtype: ome.PT_DOUBLE
+                       })
 
     def __init__(self, file_name, img_stack, pixeltype =None, channel_name=None, original_description=None, fluor=None):
         self.file_name = file_name
@@ -54,7 +60,7 @@ class TiffWriter(object):
             tifffile.imsave(fn_out, img, compress=compression, imagej=True,
                             bigtiff=bigtiff)
         elif mode == 'ome':
-            xml = self.get_xml()
+            xml = self.get_xml(dtype=dtype)
             tifffile.imsave(fn_out, img, compress=compression, imagej=False,
                             description=xml, bigtiff=bigtiff)
 
@@ -76,7 +82,11 @@ class TiffWriter(object):
     def nchannels(self):
         return self.img_stack.shape[2]
 
-    def get_xml(self):
+    def get_xml(self, dtype=None):
+        if dtype is None:
+            pixeltype = self.pixeltype_dict[dtype]
+        else:
+            pixeltype = self.pixeltype
         img = self.img_stack
         omexml = ome.OMEXML()
         omexml.image(0).Name = os.path.basename(self.file_name)
@@ -87,7 +97,7 @@ class TiffWriter(object):
         p.SizeT = 1
         p.SizeZ = 1
         p.DimensionOrder = ome.DO_XYCZT
-        p.PixelType = self.pixeltype
+        p.PixelType = pixeltype
         p.channel_count = self.nchannels
         for i in range(self.nchannels):
             channel_info = self.channel_name[i]

--- a/imctools/io/tiffwriter.py
+++ b/imctools/io/tiffwriter.py
@@ -18,14 +18,14 @@ class TiffWriter(object):
     """
 
     """
-    pixeltype_dict = ({np.int64().dtype: ome.PT_INT32,
+    pixeltype_dict = ({np.int64().dtype: ome.PT_FLOAT,
                        np.int32().dtype: ome.PT_INT32,
                        np.int16().dtype: ome.PT_INT16,
                        np.uint16().dtype: ome.PT_UINT16,
                        np.uint32().dtype: ome.PT_UINT32,
                        np.uint8().dtype: ome.PT_UINT8,
                        np.float32().dtype: ome.PT_FLOAT,
-                       np.float64().dtype: ome.PT_DOUBLE
+                       np.float64().dtype: ome.PT_FLOAT
                        })
 
     def __init__(self, file_name, img_stack, pixeltype =None, channel_name=None, original_description=None, fluor=None):

--- a/imctools/io/tiffwriter.py
+++ b/imctools/io/tiffwriter.py
@@ -46,6 +46,8 @@ class TiffWriter(object):
         img = self.img_stack.swapaxes(2, 0)
         if dtype is not None:
             dt = np.dtype(dtype)
+        else:
+            dt = np.dtype(self.pixeltype)
             img = img.astype(dt)
         # img = img.reshape([1,1]+list(img.shape)).swapaxes(2, 0)
         if mode == 'imagej':

--- a/imctools/io/tiffwriter.py
+++ b/imctools/io/tiffwriter.py
@@ -28,9 +28,18 @@ class TiffWriter(object):
                        np.uint32().dtype: ome.PT_UINT32,
                        np.uint8().dtype: ome.PT_UINT8,
                        np.float32().dtype: ome.PT_FLOAT,
-                       np.float64().dtype: ome.PT_FLOAT
+                       np.float64().dtype: ome.PT_DOUBLE
                        })
-
+    pixeltype_np = {
+            ome.PT_FLOAT: np.dtype('float32'),
+            ome.PT_DOUBLE: np.dtype('float64'),
+            ome.PT_UINT8: np.dtype('uint8'),
+            ome.PT_UINT16: np.dtype('uint16'),
+            ome.PT_UINT32: np.dtype('uint32'),
+            ome.PT_INT8: np.dtype('int8'),
+            ome.PT_INT16: np.dtype('int16'),
+            ome.PT_INT32: np.dtype('int32')
+        }
     def __init__(self, file_name, img_stack, pixeltype =None, channel_name=None, original_description=None, fluor=None):
         self.file_name = file_name
         self.img_stack = img_stack
@@ -56,7 +65,7 @@ class TiffWriter(object):
         if dtype is not None:
             dt = np.dtype(dtype)
         else:
-            dt = np.dtype(self.pixeltype)
+            dt = self.pixeltype_np[self.pixeltype]
         img = change_dtype(img, dt)
         # img = img.reshape([1,1]+list(img.shape)).swapaxes(2, 0)
         if mode == 'imagej':
@@ -131,12 +140,11 @@ def change_dtype(a, dtype):
         dinf = np.iinfo(dtype)
         mina = a.min()
         maxa = a.max()
+        a = np.around(a)
         if mina < dinf.min:
-            a = a.copy()
             a[a < dinf.min] = dinf.min
             warnings.warn('Data minimum trunkated as outside dtype range')
         if maxa > dinf.max:
-            a = a.copy()
             a[a > dinf.max] = dinf.max
             warnings.warn('Data max trunkated as outside dtype range')
     a = a.astype(dtype)

--- a/imctools/scripts/ometiff2analysis.py
+++ b/imctools/scripts/ometiff2analysis.py
@@ -6,7 +6,7 @@ import numpy as np
 from imctools.io import ometiffparser
 
 def ometiff_2_analysis(filename, outfolder, basename, pannelcsv=None, metalcolumn=None, masscolumn=None, usedcolumn=None,
-                       addsum=False, bigtiff=True, sort_channels=True):
+                       addsum=False, bigtiff=True, sort_channels=True, pixeltype=None):
     # read the pannelcsv to find out which channels should be loaded
     selmetals = None
     selmass = None
@@ -42,7 +42,7 @@ def ometiff_2_analysis(filename, outfolder, basename, pannelcsv=None, metalcolum
         img_sum = np.reshape(img_sum, list(img_sum.shape)+[1])
         writer.img_stack = np.append(img_sum, writer.img_stack, axis=2)
 
-    writer.save_image(mode='imagej', bigtiff=bigtiff)
+    writer.save_image(mode='imagej', bigtiff=bigtiff, dtype=pixeltype)
 
     if selmass is not None:
         savenames = selmass
@@ -90,8 +90,9 @@ if __name__ == "__main__":
     parser.add_argument('--usedcolumn', type=str, default='ilastik',
                         help='Column that should contain booleans (0, 1) if the channel should be used.'
                         )
-    parser.add_argument('--outformat', type=str, default='original', choices=['original', 'f', 'uint16', 'uint8', 'uint32'],
-                        help='original or f, uint32, uint16, unit8')
+    parser.add_argument('--outformat', type=str, default=None, choices=['float', 'uint16', 'uint8', 'uint32'],
+                        help='''original or float, uint32, uint16, unit8\n
+                                Per default the original pixeltype is taken''')
 
     parser.add_argument('--scale', type=str, default='no', choices=['no', 'max', 'percentile99, percentile99.9, percentile99.99'],
                         help='scale the data?' )
@@ -131,7 +132,8 @@ if __name__ == "__main__":
     ometiff_2_analysis(args.ome_filename, outfolder, fn_out, args.pannelcsv, args.metalcolumn, args.masscolumn,
                        args.usedcolumn, args.addsum == 'yes',
                        bigtiff=args.bigtiff == 'yes',
-                       sort_channels=args.sort_channels == 'yes')
+                       sort_channels=args.sort_channels == 'yes',
+                       pixeltype=outformat)
 
 
 


### PR DESCRIPTION
This allows and expands the options to export the files as uint16 and other file formats, including correct rounding and assuring that the data will be trunkated with a warning if it lies outside the range.

For this the `tiffwriter` class has been modified as well as the `ometiff2analysis` scripts.