### PR TITLE
Feature exportacquisitioncsv

### DIFF
--- a/imctools/io/mcdxmlparser.py
+++ b/imctools/io/mcdxmlparser.py
@@ -78,7 +78,7 @@ VALUEBYTES = 'ValueBytes'
 WIDTHUM = 'WidthUm'
 
 PARSER = 'parser'
-
+META_CSV = '_meta.csv'
 """
 Definition of all the meta objects
 Each entity will have a class corresponding to it, with helpermethods
@@ -315,7 +315,7 @@ class McdXmlParser(Meta):
         """
         for n, o in self.objects.items():
             odict = [i.properties for k, i in o.items()]
-            fn = '_'.join([self.metaname, n]) + '_meta.csv'
+            fn = '_'.join([self.metaname, n]) + META_CSV
             with open(os.path.join(out_folder, fn), 'w') as csvfile:
                 cols = odict[0].keys()
                 writer = csv.DictWriter(csvfile, sorted(cols))

--- a/imctools/scripts/exportacquisitioncsv.py
+++ b/imctools/scripts/exportacquisitioncsv.py
@@ -11,7 +11,6 @@ COL_ACSESSION = 'AcSession'
 SUF_CSV = '.csv'
 AC_META = 'acquisition_metadata'
 
-VAL_TEMP = 'temp'
 """
 Reads all the acquisition metadata from the ome folders and concatenates them
 to a csv that contains all the metadata.
@@ -20,9 +19,8 @@ to a csv that contains all the metadata.
 def _read_and_concat(fol_ome, suffix, idname):
     ac_names = os.listdir(fol_ome)
     dat = pd.concat([pd.read_csv(os.path.join(fol_ome, a, a+suffix)) for a in ac_names],
-                           keys=ac_names, names=[COL_ACSESSION, VAL_TEMP])
-    dat = dat.reset_index(VAL_TEMP, drop=True)
-    dat = dat.reset_index()
+                           keys=ac_names, names=COL_ACSESSION)
+    dat = dat.reset_index(VAL_ACSESSION, drop=False)
     dat = dat.rename(columns={COL_MCD_ID: COL_ACID})
     return dat
 

--- a/imctools/scripts/exportacquisitioncsv.py
+++ b/imctools/scripts/exportacquisitioncsv.py
@@ -19,8 +19,8 @@ to a csv that contains all the metadata.
 def _read_and_concat(fol_ome, suffix, idname):
     ac_names = os.listdir(fol_ome)
     dat = pd.concat([pd.read_csv(os.path.join(fol_ome, a, a+suffix)) for a in ac_names],
-                           keys=ac_names, names=COL_ACSESSION)
-    dat = dat.reset_index(VAL_ACSESSION, drop=False)
+                           keys=ac_names, names=[COL_ACSESSION])
+    dat = dat.reset_index(COL_ACSESSION, drop=False)
     dat = dat.rename(columns={COL_MCD_ID: COL_ACID})
     return dat
 
@@ -51,5 +51,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    export_acquisitionmeta(args.fol_ome, args.out_folder,
+    export_acquisition_csv(args.fol_ome, args.out_folder,
                  args.outname)

--- a/imctools/scripts/exportacquisitioncsv.py
+++ b/imctools/scripts/exportacquisitioncsv.py
@@ -34,7 +34,7 @@ def export_acquisition_csv(fol_ome, fol_out, outname=None):
     if outname is None:
         outname=AC_META
     dat_meta = read_acmeta(fol_ome)
-    dat_meta.to_csv(os.path.join(fol_out, outname+SUF_CSV))
+    dat_meta.to_csv(os.path.join(fol_out, outname+SUF_CSV), index=False)
 
 
 if __name__ == "__main__":

--- a/imctools/scripts/exportacquisitioncsv.py
+++ b/imctools/scripts/exportacquisitioncsv.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+import argparse
+import os
+import pandas as pd
+import imctools.io.mcdxmlparser as mcdmeta
+
+SUFFIX_ACMETA = '_' + mcdmeta.ACQUISITION + mcdmeta.META_CSV
+COL_MCD_ID = mcdmeta.ID
+COL_ACID = mcdmeta.ACQUISITIONID
+COL_ACSESSION = 'AcSession'
+SUF_CSV = '.csv'
+AC_META = 'acquisition_metadata'
+
+VAL_TEMP = 'temp'
+"""
+Reads all the acquisition metadata from the ome folders and concatenates them
+to a csv that contains all the metadata.
+"""
+
+def _read_and_concat(fol_ome, suffix, idname):
+    ac_names = os.listdir(fol_ome)
+    dat = pd.concat([pd.read_csv(os.path.join(fol_ome, a, a+suffix)) for a in ac_names],
+                           keys=ac_names, names=[COL_ACSESSION, VAL_TEMP])
+    dat = dat.reset_index(VAL_TEMP, drop=True)
+    dat = dat.reset_index()
+    dat = dat.rename(columns={COL_MCD_ID: COL_ACID})
+    return dat
+
+def read_acmeta(fol_ome):
+    dat_acmeta = _read_and_concat(fol_ome, SUFFIX_ACMETA, COL_ACID)
+    return dat_acmeta
+
+def export_acquisition_csv(fol_ome, fol_out, outname=None):
+    if outname is None:
+        outname=AC_META
+    dat_meta = read_acmeta(fol_ome)
+    dat_meta.to_csv(os.path.join(fol_out, outname+SUF_CSV))
+
+
+if __name__ == "__main__":
+    # Setup the command line arguments
+    parser = argparse.ArgumentParser(
+        description='Generates a metadatacsv for all acquisitions', prog='exportacquisitioncsv')
+
+    parser.add_argument('fol_ome', type=str,
+                        help='The path to the folders containing the ome tiffs.')
+
+    parser.add_argument('out_folder', type=str,
+                        help='Folder where the metadata csv should be stored in.')
+
+    parser.add_argument('--outname', type=str, default=None,
+                        help='Filename of the acquisition metadata csv')
+
+    args = parser.parse_args()
+
+    export_acquisitionmeta(args.fol_ome, args.out_folder,
+                 args.outname)

--- a/imctools/scripts/exportacquisitioncsv.py
+++ b/imctools/scripts/exportacquisitioncsv.py
@@ -28,9 +28,7 @@ def read_acmeta(fol_ome):
     dat_acmeta = _read_and_concat(fol_ome, SUFFIX_ACMETA, COL_ACID)
     return dat_acmeta
 
-def export_acquisition_csv(fol_ome, fol_out, outname=None):
-    if outname is None:
-        outname=AC_META
+def export_acquisition_csv(fol_ome, fol_out, outname=AC_META):
     dat_meta = read_acmeta(fol_ome)
     dat_meta.to_csv(os.path.join(fol_out, outname+SUF_CSV), index=False)
 
@@ -46,7 +44,7 @@ if __name__ == "__main__":
     parser.add_argument('out_folder', type=str,
                         help='Folder where the metadata csv should be stored in.')
 
-    parser.add_argument('--outname', type=str, default=None,
+    parser.add_argument('--outname', type=str, default=AC_META,
                         help='Filename of the acquisition metadata csv')
 
     args = parser.parse_args()


### PR DESCRIPTION
This adds a script that can combine the metadata of all the ome converted IMC acquisitions into a metadata table, that has the description, laserspeed, laserpower etc for each acquisition.

This file can then be used within cellprofiler to add this metadata to the images.