### PR TITLE
Fixes the converter to ignore the .schema for valid .mcd

### DIFF
--- a/imctools/scripts/convertfolder2imcfolder.py
+++ b/imctools/scripts/convertfolder2imcfolder.py
@@ -40,14 +40,13 @@ def convert_folder2imcfolder(fol, out_folder, dozip=True):
             schema_file = None
         try:
             mcd = McdParser(mcd_files[0])
-            mcd_acs = mcd.get_all_imcacquistions()
         except:
             if schema_file is not None:
                 logging.exception('Mcd File corrupted, trying to rescue with schema file')
                 mcd = McdParser(mcd_files[0], metafilename=schema_file)
-                mcd_acs = mcd.get_all_imcacquistions()
             else:
                 raise
+        mcd_acs = mcd.get_all_imcacquistions()
 
         txt_acids = {_txtfn_to_ac(f): f
                    for f in files if f.endswith(TXT_FILENDING)}

--- a/imctools/scripts/convertfolder2imcfolder.py
+++ b/imctools/scripts/convertfolder2imcfolder.py
@@ -6,6 +6,7 @@ from imctools.io.imcfolderwriter import ImcFolderWriter
 import os
 import zipfile
 import argparse
+import logging
 TXT_FILENDING = '.txt'
 MCD_FILENDING = '.mcd'
 ZIP_FILENDING = '.zip'
@@ -26,7 +27,7 @@ def convert_folder2imcfolder(fol, out_folder, dozip=True):
     else:
         in_fol = fol
         istmp = False
-    
+
     try:
         files = [os.path.join(root, fn) for root, dirs, files in os.walk(in_fol) for fn in files]
         mcd_files = [f for f in files
@@ -37,10 +38,19 @@ def convert_folder2imcfolder(fol, out_folder, dozip=True):
             schema_file = schema_files[0]
         else:
             schema_file = None
-        mcd = McdParser(mcd_files[0], metafilename=schema_file)
+        try:
+            mcd = McdParser(mcd_files[0])
+            mcd_acs = mcd.get_all_imcacquistions()
+        except:
+            if schema_file is not None:
+                logging.exception('Mcd File corrupted, trying to rescue with schema file')
+                mcd = McdParser(mcd_files[0], metafilename=schema_file)
+                mcd_acs = mcd.get_all_imcacquistions()
+            else:
+                raise
+
         txt_acids = {_txtfn_to_ac(f): f
                    for f in files if f.endswith(TXT_FILENDING)}
-        mcd_acs = mcd.get_all_imcacquistions()
         mcd_acids = set(m.image_ID for m in mcd_acs)
         txtonly_acs = set(txt_acids.keys()).difference(mcd_acids)
         for txta in txtonly_acs:
@@ -78,11 +88,11 @@ if __name__ == "__main__":
                         type=str,
                         default='',
                         help='Path to the output folder')
-    
+
     args = parser.parse_args()
     in_fol = args.folder_path
     out_fol = args.out_folder
     if out_fol == '':
         out_fol = os.path.split(in_fol)[0]
     convert_folder2imcfolder(in_fol, out_fol)
-        
+


### PR DESCRIPTION
.schema files are temporary files that are generated by the cytof
software during acquisition. They get deleted once the .mcd writing
is finished. They should only be present if the .mcd writing failed
in which case they can be used to rescue the corrupted .mcd.

Unfortunately - due to some backup schemes, the .schema file can also
be backed up before being deleted, causing the .schema file still being
present.

Convertfolder2imcfolder until now allways used the .schema
file for the metadata when present, which can lead to problems as the
backuped schema files are usually not the latest ones. Thus I changed
the code to attmept to read the .mcd without the .schema and only
attempt to consider the .schema if the .mcd cannot be decoded without
it.