### PR TITLE
idname will now be correctly passed

### DIFF
--- a/imctools/scripts/exportacquisitioncsv.py
+++ b/imctools/scripts/exportacquisitioncsv.py
@@ -21,7 +21,7 @@ def _read_and_concat(fol_ome, suffix, idname):
     dat = pd.concat([pd.read_csv(os.path.join(fol_ome, a, a+suffix)) for a in ac_names],
                            keys=ac_names, names=[COL_ACSESSION])
     dat = dat.reset_index(COL_ACSESSION, drop=False)
-    dat = dat.rename(columns={COL_MCD_ID: COL_ACID})
+    dat = dat.rename(columns={COL_MCD_ID: idname})
     return dat
 
 def read_acmeta(fol_ome):


### PR DESCRIPTION
This fixes a bug in the eportacquisitioncsv helper function `read_and_concat`
that the `idname` parameter was not passed but instead a default value was taken.
This was a bug that did not affect the library behaviour.