### PR TITLE
FIX: https://github.com/BodenmillerGroup/imctools/issues/52

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, Vito Zanotelli'
 author = 'Vito Zanotelli'
 
 # The short X.Y version
-version = '1.0.2'
+version = '1.0.3'
 # The full version, including alpha/beta/rc tags
-release = '1.0.2'
+release = '1.0.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/imctools/scripts/convertfolder2imcfolder.py
+++ b/imctools/scripts/convertfolder2imcfolder.py
@@ -20,7 +20,7 @@ def convert_folder2imcfolder(fol, out_folder, dozip=True):
     """
     if fol.endswith(ZIP_FILENDING):
         tmpdir = temporarydirectory.TemporaryDirectory()
-        with zipfile.ZipFile(fol) as zipf:
+        with zipfile.ZipFile(fol, allowZip64=True) as zipf:
             zipf.extractall(tmpdir.name)
         in_fol = tmpdir.name
         istmp = True

--- a/imctools/scripts/imc2tiff.py
+++ b/imctools/scripts/imc2tiff.py
@@ -34,7 +34,7 @@ def save_imc_to_tiff(imc_acquisition, acquisition='all', tifftype='ome',
 
     if outpath is None:
         outpath = os.path.split(imc_acquisition)[0]
-    
+
     if zip_filetype is None:
         zip_filetype = ''
 
@@ -98,7 +98,7 @@ def convert_imcfolders2tiff(folders, output_folder, common_filepart=None,
                                           fn.endswith(ZIP_FILENDING)):
                 txtname = os.path.join(fol, fn)
                 try:
-                    save_imc_to_tiff(txtname, 
+                    save_imc_to_tiff(txtname,
                                      outpath=output_folder, **kwargs)
                 except:
                     failed_images.append(txtname)
@@ -116,7 +116,7 @@ def convert_imczip2tiff(zipfn, output_folder, common_filepart=None, **kwargs):
     if common_filepart is None:
         common_filepart = ''
     with temporarydirectory.TemporaryDirectory() as tempdir:
-        with zipfile.ZipFile(zipfn) as zipf:
+        with zipfile.ZipFile(zipfn, allowZip64=True) as zipf:
             for fn in zipf.namelist():
                 if (common_filepart in fn) & fn.endswith(IMC_FILENDINGS):
                     zipf.extract(fn, tempdir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "imctools"
-version = "1.0.2"
+version = "1.0.3"
 description = "Tools to handle IMC data"
 license = "LICENSE"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('LICENSE') as f:
 
 setup(
     name='imctools',
-    version='1.0.2',
+    version='1.0.3',
     description='Tools to handle IMC data',
     long_description=readme,
     author='Vito Zanotelli',


### PR DESCRIPTION
In Python 2.x.x `allowZip64` is False by default (unlike Python 3.x.x) so it has to be explicitly set.