### PR TITLE
Fixed issue #64

### DIFF
--- a/imctools/librarybase.py
+++ b/imctools/librarybase.py
@@ -40,7 +40,7 @@ def dict_key_apply(iterable, str_fkt):
     Applys a string modifiying function to all keys of a nested dict.
     """
     if type(iterable) is dict:
-        for key in iterable.keys():
+        for key in list(iterable.keys()):
             new_key = str_fkt(key)
             iterable[new_key] = iterable.pop(key)
             if type(iterable[new_key]) is dict or type(iterable[new_key]) is list:


### PR DESCRIPTION
In Python 3.8 dict.keys() is an interator that
gives issues if the keys are changed within the loop.
I now explicitly convert the keys as a list which fixes this
issue.