### PR TITLE
Fix issue57: imctools should now ignore temporary files.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,13 +20,13 @@ sys.path.insert(0, os.path.abspath('../..'))
 # -- Project information -----------------------------------------------------
 
 project = 'imctools'
-copyright = '2019, Vito Zanotelli'
+copyright = '2020, Vito Zanotelli'
 author = 'Vito Zanotelli'
 
 # The short X.Y version
-version = '1.0.4'
+version = '1.0.6'
 # The full version, including alpha/beta/rc tags
-release = '1.0.4'
+release = '1.0.6'
 
 
 # -- General configuration ---------------------------------------------------

--- a/imctools/scripts/imc2tiff.py
+++ b/imctools/scripts/imc2tiff.py
@@ -3,6 +3,7 @@ from imctools.io import mcdparser
 from imctools.io import txtparser
 import argparse
 import os
+import glob
 from imctools.external import temporarydirectory
 import zipfile
 
@@ -93,7 +94,7 @@ def convert_imcfolders2tiff(folders, output_folder, common_filepart=None,
         common_filepart = ''
 
     for fol in folders:
-        for fn in os.listdir(fol):
+        for fn in glob.glob(os.path.join(fol, '*')):
             if (common_filepart in fn) & (fn.endswith(IMC_FILENDINGS) |
                                           fn.endswith(ZIP_FILENDING)):
                 txtname = os.path.join(fol, fn)

--- a/imctools/scripts/imc2tiff.py
+++ b/imctools/scripts/imc2tiff.py
@@ -95,15 +95,14 @@ def convert_imcfolders2tiff(folders, output_folder, common_filepart=None,
 
     for fol in folders:
         for fn in glob.glob(os.path.join(fol, '*')):
-            if (common_filepart in fn) & (fn.endswith(IMC_FILENDINGS) |
+            if (common_filepart in os.path.basename(fn)) & (fn.endswith(IMC_FILENDINGS) |
                                           fn.endswith(ZIP_FILENDING)):
-                txtname = os.path.join(fol, fn)
+                txtname = fn
                 try:
                     save_imc_to_tiff(txtname,
                                      outpath=output_folder, **kwargs)
                 except:
                     failed_images.append(txtname)
-
 
     if len(failed_images) > 0:
         print('Failed images:\n')

--- a/imctools/scripts/ome2micat.py
+++ b/imctools/scripts/ome2micat.py
@@ -2,6 +2,7 @@
 from imctools.io import ometiffparser
 import argparse
 import os
+import glob
 import shutil
 import re
 
@@ -57,9 +58,9 @@ def omefolder2micatfolder(fol_ome, outfolder, fol_masks=None, mask_suffix=None, 
     if mask_suffix is None:
         mask_suffix = '_mask.tiff'
 
-    ome_files = [fn for fn in os.listdir(fol_ome) if fn.endswith('.ome.tiff')]
+    ome_files = [fn for fn in glob.glob(os.path.join(fol_ome, '*')) if fn.endswith('.ome.tiff')]
     if fol_masks is not None:
-        fn_masks = [fn for fn in os.listdir(fol_masks) if fn.endswith(mask_suffix)]
+        fn_masks = [fn for fn in glob.glob(os.path.join(fol_masks, '*')) if fn.endswith(mask_suffix)]
     else:
         fn_masks = []
 

--- a/imctools/scripts/ome2micat.py
+++ b/imctools/scripts/ome2micat.py
@@ -39,7 +39,7 @@ def ome2micatfolder(path_ome, basefolder, path_mask=None, dtype=None):
     outfolder = os.path.join(basefolder, fn)
     if not(os.path.exists(outfolder)):
         os.makedirs(outfolder)
-    ome2singletiff(path_ome, outfolder,basename='', dtype=dtype)
+    ome2singletiff(path_ome, outfolder, basename='', dtype=dtype)
     if path_mask is not None:
         fn_mask_base = os.path.split(path_mask)[1]
         fn_mask_new = os.path.join(outfolder, fn_mask_base)
@@ -58,14 +58,15 @@ def omefolder2micatfolder(fol_ome, outfolder, fol_masks=None, mask_suffix=None, 
     if mask_suffix is None:
         mask_suffix = '_mask.tiff'
 
-    ome_files = [fn for fn in glob.glob(os.path.join(fol_ome, '*')) if fn.endswith('.ome.tiff')]
+    ome_files = [os.path.basename(fn) for fn in glob.glob(os.path.join(fol_ome, '*')) if fn.endswith('.ome.tiff')]
     if fol_masks is not None:
-        fn_masks = [fn for fn in glob.glob(os.path.join(fol_masks, '*')) if fn.endswith(mask_suffix)]
+        fn_masks = [os.path.basename(fn) for fn in glob.glob(os.path.join(fol_masks, '*')) if fn.endswith(mask_suffix)]
     else:
         fn_masks = []
 
     for fn_ome in ome_files:
-        basename_ome = fn_ome.rstrip('.ome.tiff')
+        len_suffix = len('.ome.tiff')
+        basename_ome = fn_ome[:-len_suffix]
         cur_mask = [fn for fn in fn_masks if fn.startswith(basename_ome)]
         if len(cur_mask) > 0:
             path_mask = os.path.join(fol_masks, cur_mask[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["poetry>=0.12.17"]
+requires = ["poetry>=1.0.3"]
 build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "imctools"
-version = "1.0.5"
+version = "1.0.6"
 description = "Tools to handle IMC data"
 license = "LICENSE"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('LICENSE') as f:
 
 setup(
     name='imctools',
-    version='1.0.5',
+    version='1.0.6',
     description='Tools to handle IMC data',
     long_description=readme,
     author='Vito Zanotelli',


### PR DESCRIPTION
I changed all 'os.listdir' calls with glob.glob(os.path.join(path, '*'))
which should ignore hidden files (https://stackoverflow.com/a/7099342).

This required some minor further changes, as the `glob.glob` way returns full paths not just the basenames.

Before merging this the version number still needs to be bumped.