### PR TITLE
Update README with deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 ![PyPI - License](https://img.shields.io/pypi/l/imctools)
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/BodenmillerGroup/imctools/test-and-deploy/master)
 
+**Deprecation note:** This repository is not actively maintained. For a maintained IMC file parser implementing please refer to [readimc](https://github.com/BodenmillerGroup/readimc).
+
+## Background
+
 An IMC file conversion tool that aims to convert IMC raw data files (.mcd, .txt) into an intermediary ome.tiff, containing all the relevant metadata. Further it contains tools to generate simpler TIFF files that can be directly be used as input files for e.g. CellProfiller, Ilastik, Fiji etc.
 
 Documentation is available at [https://bodenmillergroup.github.io/imctools](https://bodenmillergroup.github.io/imctools)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![PyPI - License](https://img.shields.io/pypi/l/imctools)
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/BodenmillerGroup/imctools/test-and-deploy/master)
 
-**Deprecation note:** This repository is not actively maintained. For a maintained IMC file parser implementing please refer to [readimc](https://github.com/BodenmillerGroup/readimc).
+**Deprecation note:** This repository is not actively maintained. For a maintained IMC file parser implementation please refer to [readimc](https://github.com/BodenmillerGroup/readimc).
 
 ## Background
 


### PR DESCRIPTION
Currently imctools does not seem to have a maintainer. Thus it should be deprecated in favor of readimc which is maintained.

What would be the best way to communicate the deprecation in pip? 
Maybe even add a deprecation note upon package import?
https://stackoverflow.com/a/24110281

Any opinions?